### PR TITLE
add a patch to add the --force flag for ansible-galaxy

### DIFF
--- a/patches/13-ansible-galaxy-force.patch
+++ b/patches/13-ansible-galaxy-force.patch
@@ -1,0 +1,12 @@
+diff -up ./internal/plugins/ansible/v1/scaffolds/internal/templates/dockerfile.go.orig ./internal/plugins/ansible/v1/scaffolds/internal/templates/dockerfile.go
+--- ./internal/plugins/ansible/v1/scaffolds/internal/templates/dockerfile.go.orig	2023-08-14 12:35:36.067594994 -0400
++++ ./internal/plugins/ansible/v1/scaffolds/internal/templates/dockerfile.go	2023-08-14 12:35:43.951646487 -0400
+@@ -57,7 +57,7 @@ func (f *Dockerfile) SetTemplateDefaults
+ const dockerfileTemplate = `FROM quay.io/operator-framework/ansible-operator:{{ .AnsibleOperatorVersion }}
+ 
+ COPY requirements.yml ${HOME}/requirements.yml
+-RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
++RUN ansible-galaxy collection install --force -r ${HOME}/requirements.yml \
+  && chmod -R ug+rwx ${HOME}/.ansible
+ 
+ COPY watches.yaml ${HOME}/watches.yaml


### PR DESCRIPTION
**Description**:
- Adds a patch file to force generated dockerfiles for ansible based operators to use the `--force` flag
