### PR TITLE
add patch for ansible testdata dockerfile

### DIFF
--- a/patches/14-ansible-testdata-galaxy-force.patch
+++ b/patches/14-ansible-testdata-galaxy-force.patch
@@ -1,0 +1,12 @@
+diff -up ./testdata/ansible/memcached-operator/Dockerfile.orig ./testdata/ansible/memcached-operator/Dockerfile
+--- ./testdata/ansible/memcached-operator/Dockerfile.orig	2023-08-15 12:49:26.636536258 -0400
++++ ./testdata/ansible/memcached-operator/Dockerfile	2023-08-15 12:49:45.292628995 -0400
+@@ -1,7 +1,7 @@
+ FROM quay.io/operator-framework/ansible-operator:v1.31.0
+ 
+ COPY requirements.yml ${HOME}/requirements.yml
+-RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
++RUN ansible-galaxy collection install --force -r ${HOME}/requirements.yml \
+  && chmod -R ug+rwx ${HOME}/.ansible
+ 
+ COPY watches.yaml ${HOME}/watches.yaml


### PR DESCRIPTION
Looks like e2e tests copy over the testdata but will apply patches first. To make sure we are forcing ansible galaxy updates I added a patch for the ansible operator testdata dockerfile